### PR TITLE
chore!: bump `embedded-hal-async` to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = [
 ]
 
 [dependencies]
-embedded-hal-async = "0.2.0-alpha.0"
+embedded-hal-async = "1.0.0"
 defmt = { version = "0.3", optional = true }


### PR DESCRIPTION
First, thank you for your work on this crate!

This bumps the `embedded-hal-async` dependency so `hts221-async` can easily be used with other crates from that version. `hts221-async` still seems to be the most recently maintained crate for that sensor.

I think this is a breaking change as `Hts221` now requires an I2C driver implementing a newer trait.

We do have a use case for this crate at [Ariel OS](https://github.com/ariel-os/ariel-os).

## Testing

I had a cursory look at the imported items but it wasn't so easy because of the wildcard imports. This does however work for me in hardware, at least for `read()`ing a value on a instantiated and initialized `Hts221` driver. 

