### PR TITLE
build: allow compiling on stable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,0 @@
-# Before upgrading check that everything is available on all tier1 targets here:
-# https://rust-lang.github.io/rustup-components-history
-[toolchain]
-channel = "nightly-2022-11-22"
-components = [ "rust-src", "rustfmt"]
-targets = [ "thumbv7em-none-eabi" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(type_alias_impl_trait)]
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 


### PR DESCRIPTION
Following #1, I think this crate can now be compiled on stable. This removes an unstable feature which I believe was unused, and unpins the toolchain.

## PR dependencies

Depends on #1 (feel free to rebase this PR when needed).

## Testing

`cargo test` runs successfully with Rust 1.88.